### PR TITLE
refactor(probes): ProbeEntry.id → stem, *_PROBE_ID → *_PROBE_STEM

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,27 +1,27 @@
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DISCOVERY_PROBE_STEM, discoveryProbe } from './probes/discovery.js';
-import { PRM_PROBE_ID, prmProbe } from './probes/prm.js';
-import { AS_METADATA_PROBE_ID, asMetadataProbe } from './probes/as-metadata.js';
-import { DCR_PROBE_ID, dcrProbe } from './probes/dcr.js';
-import { PKCE_PROBE_ID, pkceEnforcementProbe } from './probes/pkce-enforcement.js';
-import { TOKEN_HYGIENE_PROBE_ID, tokenHygieneProbe } from './probes/token-hygiene.js';
+import { PRM_PROBE_STEM, prmProbe } from './probes/prm.js';
+import { AS_METADATA_PROBE_STEM, asMetadataProbe } from './probes/as-metadata.js';
+import { DCR_PROBE_STEM, dcrProbe } from './probes/dcr.js';
+import { PKCE_PROBE_STEM, pkceEnforcementProbe } from './probes/pkce-enforcement.js';
+import { TOKEN_HYGIENE_PROBE_STEM, tokenHygieneProbe } from './probes/token-hygiene.js';
 import { writeEvidence } from './evidence.js';
 import { writeReport } from './report.js';
 import type { AuditContext, Finding, Probe } from './types.js';
 
 interface ProbeEntry {
-  id: string;
+  stem: string;
   run: Probe;
 }
 
 const probes: ProbeEntry[] = [
-  { id: DISCOVERY_PROBE_STEM, run: discoveryProbe },
-  { id: PRM_PROBE_ID, run: prmProbe },
-  { id: AS_METADATA_PROBE_ID, run: asMetadataProbe },
-  { id: DCR_PROBE_ID, run: dcrProbe },
-  { id: PKCE_PROBE_ID, run: pkceEnforcementProbe },
-  { id: TOKEN_HYGIENE_PROBE_ID, run: tokenHygieneProbe }
+  { stem: DISCOVERY_PROBE_STEM, run: discoveryProbe },
+  { stem: PRM_PROBE_STEM, run: prmProbe },
+  { stem: AS_METADATA_PROBE_STEM, run: asMetadataProbe },
+  { stem: DCR_PROBE_STEM, run: dcrProbe },
+  { stem: PKCE_PROBE_STEM, run: pkceEnforcementProbe },
+  { stem: TOKEN_HYGIENE_PROBE_STEM, run: tokenHygieneProbe }
 ];
 
 export async function runAudit(target: string, outputRoot: string): Promise<void> {
@@ -55,8 +55,8 @@ export async function runAudit(target: string, outputRoot: string): Promise<void
       // the audit continues. No probe can halt the run.
       const message = err instanceof Error ? err.message : String(err);
       findings.push({
-        id: probe.id,
-        title: `${probe.id} threw`,
+        id: probe.stem,
+        title: `${probe.stem} threw`,
         severity: 'issue',
         passed: false,
         observations: [message]

--- a/src/probes/as-metadata.ts
+++ b/src/probes/as-metadata.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { AuditContext, Evidence, Finding, ProbeResult } from '../types.js';
 
-export const AS_METADATA_PROBE_ID = '03-as-metadata';
+export const AS_METADATA_PROBE_STEM = '03-as-metadata';
 export const AS_METADATA_ISSUER_VALIDATION_FINDING_ID = '03-as-metadata-issuer-validation';
 export const AS_METADATA_PKCE_METHODS_FINDING_ID = '03-as-metadata-pkce-methods';
 export const AS_METADATA_MULTI_AS_FINDING_ID = '03-as-metadata-multi-as';
@@ -46,7 +46,7 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
   const servers = ctx.authorizationServers;
   if (!servers || servers.length === 0) {
     const finding: Finding = {
-      id: AS_METADATA_PROBE_ID,
+      id: AS_METADATA_PROBE_STEM,
       title: 'Authorization Server metadata (RFC 8414)',
       severity: 'skipped',
       passed: false,
@@ -186,12 +186,12 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
   }
 
   const finding: Finding = {
-    id: AS_METADATA_PROBE_ID,
+    id: AS_METADATA_PROBE_STEM,
     title: 'Authorization Server metadata (RFC 8414)',
     severity: passed ? 'info' : 'warn',
     passed,
     observations,
-    evidence: [AS_METADATA_PROBE_ID]
+    evidence: [AS_METADATA_PROBE_STEM]
   };
 
   const a5Finding = buildIssuerValidationFinding(metadataParsed, issuerMismatch, returnedIssuer, issuer);
@@ -207,13 +207,13 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
       observations: [
         `AS metadata lists ${servers.length} authorization_servers entries. Probe 3 v0 audits only the first (${servers[0]}). Remaining: ${servers.slice(1).join(', ')}. Multi-AS coverage is planned for a future probe revision.`
       ],
-      evidence: [AS_METADATA_PROBE_ID]
+      evidence: [AS_METADATA_PROBE_STEM]
     });
   }
 
   const result: ProbeResult = {
     findings,
-    evidence: [{ name: AS_METADATA_PROBE_ID, evidence }]
+    evidence: [{ name: AS_METADATA_PROBE_STEM, evidence }]
   };
   if (contextUpdates) {
     result.contextUpdates = contextUpdates;
@@ -263,7 +263,7 @@ function buildIssuerValidationFinding(
         'RFC 8414 §3.3 MUST: the issuer value in the metadata response MUST be identical to the issuer identifier value used to construct the well-known URI.',
         'RFC 8414 §3.3 MUST NOT: the data contained in this response MUST NOT be used. contextUpdates suppressed; downstream probes will not receive authorization_endpoint, token_endpoint, or registration_endpoint from this response.'
       ],
-      evidence: [AS_METADATA_PROBE_ID]
+      evidence: [AS_METADATA_PROBE_STEM]
     };
   }
 
@@ -275,7 +275,7 @@ function buildIssuerValidationFinding(
     observations: [
       `Returned issuer "${returnedIssuer ?? ''}" matches the expected issuer identifier. RFC 8414 §3.3 MUST satisfied.`
     ],
-    evidence: [AS_METADATA_PROBE_ID]
+    evidence: [AS_METADATA_PROBE_STEM]
   };
 }
 
@@ -311,7 +311,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
         'code_challenge_methods_supported not present in AS metadata.',
         'RFC 8414 §2: if omitted, the authorization server does not support PKCE.'
       ],
-      evidence: [AS_METADATA_PROBE_ID]
+      evidence: [AS_METADATA_PROBE_STEM]
     };
   }
 
@@ -329,7 +329,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
         methodsLine,
         'S256 advertised; plain not advertised. RFC 7636 §4.2 MTI baseline satisfied.'
       ],
-      evidence: [AS_METADATA_PROBE_ID]
+      evidence: [AS_METADATA_PROBE_STEM]
     };
   }
 
@@ -346,7 +346,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
         'RFC 7636 §4.2 designates S256 as MTI on the server and requires clients capable of S256 to use it.',
         'OAuth 2.1 draft-15 §4.1.1 permits plain in AS metadata as a fallback discovery path for clients that cannot support S256.'
       ],
-      evidence: [AS_METADATA_PROBE_ID]
+      evidence: [AS_METADATA_PROBE_STEM]
     };
   }
 
@@ -360,7 +360,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
       methodsLine,
       'S256 is not advertised. RFC 7636 §4.2 designates S256 as Mandatory To Implement (MTI) on the server. Without S256 in the advertised methods, clients cannot use the MTI baseline regardless of their own capability.'
     ],
-    evidence: [AS_METADATA_PROBE_ID]
+    evidence: [AS_METADATA_PROBE_STEM]
   };
 }
 

--- a/src/probes/dcr.ts
+++ b/src/probes/dcr.ts
@@ -7,7 +7,7 @@ import type {
   ProbeResult
 } from '../types.js';
 
-export const DCR_PROBE_ID = '04-dcr';
+export const DCR_PROBE_STEM = '04-dcr';
 
 const EVIDENCE_NAME_VALID = '04-dcr-register-valid';
 const EVIDENCE_NAME_HTTP_REDIRECT = '04-dcr-register-http-redirect';
@@ -55,7 +55,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   const as = ctx.authorizationServerMetadata;
   if (!as) {
     const skipFinding: Finding = {
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR/CIMD probe skipped: AS metadata not available',
       severity: 'skipped',
       passed: false,
@@ -74,7 +74,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   const cimdSupported = cimdSupportedRaw === true;
   if (cimdSupported) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'CIMD advertised',
       severity: 'info',
       passed: true,
@@ -84,7 +84,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'CIMD not advertised',
       severity: 'info',
       passed: false,
@@ -98,7 +98,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   const registrationEndpoint = as.registration_endpoint;
   if (!registrationEndpoint) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR not advertised',
       severity: 'info',
       passed: false,
@@ -111,7 +111,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (!registrationEndpoint.startsWith('https://')) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR endpoint not TLS-protected',
       severity: 'issue',
       passed: false,
@@ -122,7 +122,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   }
 
   findings.push({
-    id: DCR_PROBE_ID,
+    id: DCR_PROBE_STEM,
     title: 'DCR advertised',
     severity: 'info',
     passed: true,
@@ -153,7 +153,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (attempt1.status === 201 && body1Validated?.success) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR valid registration accepted',
       severity: 'info',
       passed: true,
@@ -165,7 +165,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     contextUpdates = { registeredClient: body1Validated.data };
   } else if (attempt1.status === 200 && body1Validated?.success) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR registration response uses HTTP 200 instead of 201',
       severity: 'warn',
       passed: false,
@@ -177,7 +177,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     contextUpdates = { registeredClient: body1Validated.data };
   } else if (attempt1.status === 200) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR registration returned 200 but response lacks valid client_id',
       severity: 'issue',
       passed: false,
@@ -188,7 +188,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else if (attempt1.status === 201) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR registration returned 201 but response lacks valid client_id',
       severity: 'issue',
       passed: false,
@@ -199,7 +199,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR valid registration rejected by server',
       severity: 'info',
       passed: false,
@@ -226,7 +226,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (attempt2.status === 201) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR accepted HTTP redirect URI for confidential client',
       severity: 'issue',
       passed: false,
@@ -237,7 +237,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR rejected HTTP redirect URI for confidential client',
       severity: 'info',
       passed: true,
@@ -263,7 +263,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (attempt3.status === 201) {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR accepted host-mismatched redirect URI',
       severity: 'warn',
       passed: false,
@@ -274,7 +274,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else {
     findings.push({
-      id: DCR_PROBE_ID,
+      id: DCR_PROBE_STEM,
       title: 'DCR rejected host-mismatched redirect URI',
       severity: 'info',
       passed: true,

--- a/src/probes/pkce-enforcement.ts
+++ b/src/probes/pkce-enforcement.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { z } from 'zod';
 import type { AuditContext, Evidence, Finding, NamedEvidence, ProbeResult } from '../types.js';
 
-export const PKCE_PROBE_ID = '05-pkce-enforcement';
+export const PKCE_PROBE_STEM = '05-pkce-enforcement';
 export const PKCE_NO_CHALLENGE_FINDING_ID = '05-pkce-enforcement-no-challenge';
 export const PKCE_PLAIN_FINDING_ID = '05-pkce-enforcement-plain';
 export const PKCE_STATE_ECHO_FINDING_ID = '05-pkce-enforcement-state-echo';
@@ -68,7 +68,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   const authzEndpoint = ctx.authorizationEndpoint;
   if (!as || !authzEndpoint) {
     findings.push({
-      id: PKCE_PROBE_ID,
+      id: PKCE_PROBE_STEM,
       title: 'PKCE enforcement probe skipped: AS metadata not available',
       severity: 'skipped',
       passed: false,
@@ -83,7 +83,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   const clientResult = RegisteredClientSchema.safeParse(ctx.registeredClient);
   if (!clientResult.success) {
     findings.push({
-      id: PKCE_PROBE_ID,
+      id: PKCE_PROBE_STEM,
       title: 'PKCE enforcement probe skipped: no registered client',
       severity: 'skipped',
       passed: false,
@@ -99,7 +99,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   const pkceMethods = as.code_challenge_methods_supported;
   if (!pkceMethods || pkceMethods.length === 0) {
     findings.push({
-      id: PKCE_PROBE_ID,
+      id: PKCE_PROBE_STEM,
       title: 'PKCE not advertised; enforcement test not applicable',
       severity: 'info',
       passed: false,

--- a/src/probes/prm.ts
+++ b/src/probes/prm.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { AuditContext, Evidence, Finding, NamedEvidence, ProbeResult } from '../types.js';
 
-export const PRM_PROBE_ID = '02-prm';
+export const PRM_PROBE_STEM = '02-prm';
 
 /**
  * Protected Resource Metadata, per RFC 9728 §3.
@@ -44,7 +44,7 @@ const RECOMMENDED_FIELDS = [
 export async function prmProbe(ctx: AuditContext): Promise<ProbeResult> {
   const prmUrl = ctx.protectedResourceMetadataUrl;
   if (prmUrl) {
-    return fetchAndValidate(ctx, prmUrl, PRM_PROBE_ID);
+    return fetchAndValidate(ctx, prmUrl, PRM_PROBE_STEM);
   }
 
   return runFallback(ctx);
@@ -160,7 +160,7 @@ async function fetchAndValidate(
   const validation = validatePrmResponse(ctx, attempt);
 
   const finding: Finding = {
-    id: PRM_PROBE_ID,
+    id: PRM_PROBE_STEM,
     title: 'Protected Resource Metadata (RFC 9728)',
     severity: validation.passed ? 'info' : 'warn',
     passed: validation.passed,
@@ -195,7 +195,7 @@ function fallbackSuccess(
   const validation = validatePrmResponse(ctx, attempt);
 
   const validationFinding: Finding = {
-    id: PRM_PROBE_ID,
+    id: PRM_PROBE_STEM,
     title: 'Protected Resource Metadata (RFC 9728)',
     severity: validation.passed ? 'info' : 'warn',
     passed: validation.passed,
@@ -206,7 +206,7 @@ function fallbackSuccess(
   }
 
   const infoFinding: Finding = {
-    id: PRM_PROBE_ID,
+    id: PRM_PROBE_STEM,
     title: 'PRM discovery required well-known URL fallback',
     severity: 'info',
     passed: true,
@@ -260,7 +260,7 @@ function fallbackAllFailed(input: FallbackFailureInput): ProbeResult {
     : `WWW-Authenticate lacks resource_metadata parameter. Well-known URL path-insertion form (${input.pathInsertUrl}) returned ${input.pathInsertStatus}; top-level form (${input.topLevelUrl}) returned ${input.topLevelStatus}. A spec-compliant client cannot complete discovery.`;
 
   const finding: Finding = {
-    id: PRM_PROBE_ID,
+    id: PRM_PROBE_STEM,
     title: 'No RFC 9728 discovery path resolves',
     severity: 'issue',
     passed: false,

--- a/src/probes/token-hygiene.ts
+++ b/src/probes/token-hygiene.ts
@@ -1,6 +1,6 @@
 import type { AuditContext, Finding, ProbeResult } from '../types.js';
 
-export const TOKEN_HYGIENE_PROBE_ID = '06-token-hygiene';
+export const TOKEN_HYGIENE_PROBE_STEM = '06-token-hygiene';
 export const TOKEN_HYGIENE_JWKS_URI_FINDING_ID = '06-token-hygiene-jwks-uri';
 export const TOKEN_HYGIENE_REVOCATION_FINDING_ID = '06-token-hygiene-revocation-endpoint';
 export const TOKEN_HYGIENE_INTROSPECTION_FINDING_ID = '06-token-hygiene-introspection-endpoint';


### PR DESCRIPTION
Mechanical rename. Completes the convention started in
discovery.ts (DISCOVERY_PROBE_STEM) by propagating *_PROBE_STEM
to the other five probes and renaming ProbeEntry.id → stem in
src/audit.ts.

Closes the carried open item: \`ProbeEntry.id → ProbeEntry.stem
rename pending next time src/audit.ts is touched\`.

No behavioral change. CI gate: build green, typecheck green
(no test suite defined yet), smoke audit against
api.githubcopilot.com/mcp/ runs to completion.