### PR TITLE
Citation accuracy in probes 02/04 plus Finding.id rename to Finding.stem

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -55,7 +55,7 @@ export async function runAudit(target: string, outputRoot: string): Promise<void
       // the audit continues. No probe can halt the run.
       const message = err instanceof Error ? err.message : String(err);
       findings.push({
-        id: probe.stem,
+        stem: probe.stem,
         title: `${probe.stem} threw`,
         severity: 'issue',
         passed: false,

--- a/src/probes/as-metadata.ts
+++ b/src/probes/as-metadata.ts
@@ -46,7 +46,7 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
   const servers = ctx.authorizationServers;
   if (!servers || servers.length === 0) {
     const finding: Finding = {
-      id: AS_METADATA_PROBE_STEM,
+      stem: AS_METADATA_PROBE_STEM,
       title: 'Authorization Server metadata (RFC 8414)',
       severity: 'skipped',
       passed: false,
@@ -58,14 +58,14 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
     // the post-fetch path.
     const zeroAsSkipObservation = 'Skipped: probe 2 did not discover any authorization_servers.';
     const a5Finding: Finding = {
-      id: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
+      stem: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
       title: A5_TITLE,
       severity: 'skipped',
       passed: false,
       observations: [zeroAsSkipObservation]
     };
     const a4Finding: Finding = {
-      id: AS_METADATA_PKCE_METHODS_FINDING_ID,
+      stem: AS_METADATA_PKCE_METHODS_FINDING_ID,
       title: A4_TITLE,
       severity: 'skipped',
       passed: false,
@@ -186,7 +186,7 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
   }
 
   const finding: Finding = {
-    id: AS_METADATA_PROBE_STEM,
+    stem: AS_METADATA_PROBE_STEM,
     title: 'Authorization Server metadata (RFC 8414)',
     severity: passed ? 'info' : 'warn',
     passed,
@@ -200,7 +200,7 @@ export async function asMetadataProbe(ctx: AuditContext): Promise<ProbeResult> {
   const findings: Finding[] = [finding, a5Finding, a4Finding];
   if (servers.length > 1) {
     findings.push({
-      id: AS_METADATA_MULTI_AS_FINDING_ID,
+      stem: AS_METADATA_MULTI_AS_FINDING_ID,
       title: 'Multi-AS configuration not fully audited',
       severity: 'info',
       passed: false,
@@ -243,7 +243,7 @@ function buildIssuerValidationFinding(
 ): Finding {
   if (!metadataParsed) {
     return {
-      id: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
+      stem: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
       title: A5_TITLE,
       severity: 'skipped',
       passed: false,
@@ -253,7 +253,7 @@ function buildIssuerValidationFinding(
 
   if (issuerMismatch) {
     return {
-      id: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
+      stem: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
       title: A5_TITLE,
       severity: 'issue',
       passed: false,
@@ -268,7 +268,7 @@ function buildIssuerValidationFinding(
   }
 
   return {
-    id: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
+    stem: AS_METADATA_ISSUER_VALIDATION_FINDING_ID,
     title: A5_TITLE,
     severity: 'info',
     passed: true,
@@ -293,7 +293,7 @@ function buildIssuerValidationFinding(
 function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undefined): Finding {
   if (!metadataParsed) {
     return {
-      id: AS_METADATA_PKCE_METHODS_FINDING_ID,
+      stem: AS_METADATA_PKCE_METHODS_FINDING_ID,
       title: A4_TITLE,
       severity: 'skipped',
       passed: false,
@@ -303,7 +303,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
 
   if (pkce === undefined) {
     return {
-      id: AS_METADATA_PKCE_METHODS_FINDING_ID,
+      stem: AS_METADATA_PKCE_METHODS_FINDING_ID,
       title: A4_TITLE,
       severity: 'info',
       passed: false,
@@ -321,7 +321,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
 
   if (hasS256 && !hasPlain) {
     return {
-      id: AS_METADATA_PKCE_METHODS_FINDING_ID,
+      stem: AS_METADATA_PKCE_METHODS_FINDING_ID,
       title: A4_TITLE,
       severity: 'info',
       passed: true,
@@ -335,7 +335,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
 
   if (hasS256 && hasPlain) {
     return {
-      id: AS_METADATA_PKCE_METHODS_FINDING_ID,
+      stem: AS_METADATA_PKCE_METHODS_FINDING_ID,
       title: A4_TITLE,
       severity: 'warn',
       passed: false,
@@ -352,7 +352,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
 
   // pkce present but does not include 'S256' (may include 'plain' or other values).
   return {
-    id: AS_METADATA_PKCE_METHODS_FINDING_ID,
+    stem: AS_METADATA_PKCE_METHODS_FINDING_ID,
     title: A4_TITLE,
     severity: 'issue',
     passed: false,

--- a/src/probes/dcr.ts
+++ b/src/probes/dcr.ts
@@ -43,7 +43,8 @@ interface DcrRegistrationPayload {
  *
  * Methodology step 3 (client registration surface). Covers:
  *   (a) Presence/TLS of `registration_endpoint` (RFC 7591 §3).
- *   (b) Active redirect-URI validation via three POSTs (RFC 7591 §5).
+ *   (b) Active redirect-URI validation via three POSTs (RFC 7591 §5
+ *       host-match SHOULD; OAuth 2.1 §1.5 https MUST).
  *   (c) Passive CIMD flag advertisement
  *       (draft-ietf-oauth-client-id-metadata-document-01 §5).
  *
@@ -55,7 +56,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   const as = ctx.authorizationServerMetadata;
   if (!as) {
     const skipFinding: Finding = {
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR/CIMD probe skipped: AS metadata not available',
       severity: 'skipped',
       passed: false,
@@ -74,7 +75,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   const cimdSupported = cimdSupportedRaw === true;
   if (cimdSupported) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'CIMD advertised',
       severity: 'info',
       passed: true,
@@ -84,7 +85,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'CIMD not advertised',
       severity: 'info',
       passed: false,
@@ -98,7 +99,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   const registrationEndpoint = as.registration_endpoint;
   if (!registrationEndpoint) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR not advertised',
       severity: 'info',
       passed: false,
@@ -111,7 +112,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (!registrationEndpoint.startsWith('https://')) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR endpoint not TLS-protected',
       severity: 'issue',
       passed: false,
@@ -122,7 +123,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
   }
 
   findings.push({
-    id: DCR_PROBE_STEM,
+    stem: DCR_PROBE_STEM,
     title: 'DCR advertised',
     severity: 'info',
     passed: true,
@@ -153,7 +154,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (attempt1.status === 201 && body1Validated?.success) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR valid registration accepted',
       severity: 'info',
       passed: true,
@@ -165,30 +166,30 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     contextUpdates = { registeredClient: body1Validated.data };
   } else if (attempt1.status === 200 && body1Validated?.success) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR registration response uses HTTP 200 instead of 201',
       severity: 'warn',
       passed: false,
       observations: [
-        `POST returned 200 with client_id=<redacted>. RFC 7591 §3.2.1 MUST requires HTTP 201 for successful registration. Context populated; downstream probes may proceed.`
+        `POST returned 200 with client_id=<redacted>. RFC 7591 §3.2 specifies HTTP 201 for a successful registration. Context populated; downstream probes may proceed.`
       ],
       evidence: [EVIDENCE_NAME_VALID]
     });
     contextUpdates = { registeredClient: body1Validated.data };
   } else if (attempt1.status === 200) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR registration returned 200 but response lacks valid client_id',
       severity: 'issue',
       passed: false,
       observations: [
-        'POST returned 200 but body does not contain a valid client_id. RFC 7591 §3.2.1 MUST requires HTTP 201 and a client_id in the response body. Context not populated.'
+        'POST returned 200 but body does not contain a valid client_id. RFC 7591 §3.2 specifies HTTP 201 for a successful registration, and §3.2.1 requires a client_id in the response body. Context not populated.'
       ],
       evidence: [EVIDENCE_NAME_VALID]
     });
   } else if (attempt1.status === 201) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR registration returned 201 but response lacks valid client_id',
       severity: 'issue',
       passed: false,
@@ -199,7 +200,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   } else {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR valid registration rejected by server',
       severity: 'info',
       passed: false,
@@ -210,7 +211,7 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
     });
   }
 
-  // POST 2: HTTP redirect URI for confidential client (MUST violation probe).
+  // POST 2: non-loopback HTTP redirect URI (OAuth 2.1 §1.5 MUST violation).
   // redirect_uri uses HTTP scheme; host matches client_uri so the scheme is
   // the sole isolated variable.
   const payload2: DcrRegistrationPayload = {
@@ -226,23 +227,23 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (attempt2.status === 201) {
     findings.push({
-      id: DCR_PROBE_STEM,
-      title: 'DCR accepted HTTP redirect URI for confidential client',
+      stem: DCR_PROBE_STEM,
+      title: 'DCR accepted non-loopback HTTP redirect URI',
       severity: 'issue',
       passed: false,
       observations: [
-        'POST returned 201; HTTP redirect URIs must be rejected for confidential clients (RFC 7591 §5 MUST).'
+        'POST returned 201; non-loopback HTTP redirect URIs must be rejected (OAuth 2.1 §1.5 MUST). The https requirement applies to all redirect-based clients; the client_secret_basic client here only isolates the scheme as the single variable.'
       ],
       evidence: [EVIDENCE_NAME_HTTP_REDIRECT]
     });
   } else {
     findings.push({
-      id: DCR_PROBE_STEM,
-      title: 'DCR rejected HTTP redirect URI for confidential client',
+      stem: DCR_PROBE_STEM,
+      title: 'DCR rejected non-loopback HTTP redirect URI',
       severity: 'info',
       passed: true,
       observations: [
-        `POST returned HTTP ${attempt2.status} as expected (RFC 7591 §5).`
+        `POST returned HTTP ${attempt2.status} as expected (OAuth 2.1 §1.5).`
       ],
       evidence: [EVIDENCE_NAME_HTTP_REDIRECT]
     });
@@ -263,18 +264,18 @@ export async function dcrProbe(ctx: AuditContext): Promise<ProbeResult> {
 
   if (attempt3.status === 201) {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR accepted host-mismatched redirect URI',
       severity: 'warn',
       passed: false,
       observations: [
-        'POST returned 201; redirect_uri host differs from client_uri host. AS SHOULD reject this (RFC 7591 §5 SHOULD).'
+        'POST returned 201; redirect_uri host differs from client_uri host. AS SHOULD check this; §5 frames it as a host and scheme check that may lead to refusal, not a mandated rejection (RFC 7591 §5 SHOULD).'
       ],
       evidence: [EVIDENCE_NAME_HOST_MISMATCH]
     });
   } else {
     findings.push({
-      id: DCR_PROBE_STEM,
+      stem: DCR_PROBE_STEM,
       title: 'DCR rejected host-mismatched redirect URI',
       severity: 'info',
       passed: true,

--- a/src/probes/discovery.ts
+++ b/src/probes/discovery.ts
@@ -109,7 +109,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
   }
 
   const a1Finding: Finding = {
-    id: A1_FINDING_ID,
+    stem: A1_FINDING_ID,
     title: A1_TITLE,
     severity: a1Passed ? 'info' : 'issue',
     passed: a1Passed,
@@ -122,7 +122,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
   let a2Finding: Finding;
   if (!a1Passed) {
     a2Finding = {
-      id: A2_FINDING_ID,
+      stem: A2_FINDING_ID,
       title: A2_TITLE,
       severity: 'skipped',
       passed: false,
@@ -130,7 +130,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
     };
   } else if (prmUrl !== null) {
     a2Finding = {
-      id: A2_FINDING_ID,
+      stem: A2_FINDING_ID,
       title: A2_TITLE,
       severity: 'info',
       passed: true,
@@ -139,7 +139,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
     };
   } else {
     a2Finding = {
-      id: A2_FINDING_ID,
+      stem: A2_FINDING_ID,
       title: A2_TITLE,
       severity: 'warn',
       passed: false,
@@ -155,7 +155,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
   let a3Finding: Finding;
   if (!a1Passed || challenge === null || wwwAuth === null) {
     a3Finding = {
-      id: A3_FINDING_ID,
+      stem: A3_FINDING_ID,
       title: A3_TITLE,
       severity: 'skipped',
       passed: false,
@@ -181,7 +181,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
         );
       }
       a3Finding = {
-        id: A3_FINDING_ID,
+        stem: A3_FINDING_ID,
         title: A3_TITLE,
         severity: 'warn',
         passed: false,
@@ -193,7 +193,7 @@ export async function discoveryProbe(ctx: AuditContext): Promise<ProbeResult> {
         'No error, error_description, or error_uri parameter present.'
       );
       a3Finding = {
-        id: A3_FINDING_ID,
+        stem: A3_FINDING_ID,
         title: A3_TITLE,
         severity: 'info',
         passed: true,

--- a/src/probes/pkce-enforcement.ts
+++ b/src/probes/pkce-enforcement.ts
@@ -68,7 +68,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   const authzEndpoint = ctx.authorizationEndpoint;
   if (!as || !authzEndpoint) {
     findings.push({
-      id: PKCE_PROBE_STEM,
+      stem: PKCE_PROBE_STEM,
       title: 'PKCE enforcement probe skipped: AS metadata not available',
       severity: 'skipped',
       passed: false,
@@ -83,7 +83,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   const clientResult = RegisteredClientSchema.safeParse(ctx.registeredClient);
   if (!clientResult.success) {
     findings.push({
-      id: PKCE_PROBE_STEM,
+      stem: PKCE_PROBE_STEM,
       title: 'PKCE enforcement probe skipped: no registered client',
       severity: 'skipped',
       passed: false,
@@ -99,7 +99,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   const pkceMethods = as.code_challenge_methods_supported;
   if (!pkceMethods || pkceMethods.length === 0) {
     findings.push({
-      id: PKCE_PROBE_STEM,
+      stem: PKCE_PROBE_STEM,
       title: 'PKCE not advertised; enforcement test not applicable',
       severity: 'info',
       passed: false,
@@ -141,7 +141,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
   // --- Test 2: code_challenge_method=plain (skipped when plain advertised) ---
   if (pkceMethods.includes('plain')) {
     findings.push({
-      id: PKCE_PLAIN_FINDING_ID,
+      stem: PKCE_PLAIN_FINDING_ID,
       title: 'Plain method enforcement test skipped: plain is advertised',
       severity: 'skipped',
       passed: false,
@@ -176,7 +176,7 @@ export async function pkceEnforcementProbe(ctx: AuditContext): Promise<ProbeResu
 
   // Verifier-mismatch deferral (always emitted when probe ran tests).
   findings.push({
-    id: PKCE_VERIFIER_MISMATCH_FINDING_ID,
+    stem: PKCE_VERIFIER_MISMATCH_FINDING_ID,
     title: 'Verifier-mismatch test deferred to future probe',
     severity: 'skipped',
     passed: false,
@@ -256,7 +256,7 @@ function classifyAndEmit(
 
       if (error) {
         findings.push({
-          id: params.primaryFindingId,
+          stem: params.primaryFindingId,
           title: `Authorization endpoint rejected ${params.primaryFindingTitleSubject}`,
           severity: 'info',
           passed: true,
@@ -267,7 +267,7 @@ function classifyAndEmit(
         });
       } else if (code) {
         findings.push({
-          id: params.primaryFindingId,
+          stem: params.primaryFindingId,
           title: params.codeIssuedTitle,
           severity: 'issue',
           passed: false,
@@ -278,7 +278,7 @@ function classifyAndEmit(
         });
       } else {
         findings.push({
-          id: params.primaryFindingId,
+          stem: params.primaryFindingId,
           title: 'Authorization endpoint redirected to redirect_uri without code or error',
           severity: 'warn',
           passed: false,
@@ -293,7 +293,7 @@ function classifyAndEmit(
       const echoedState = query.get('state');
       if (echoedState !== sentState) {
         findings.push({
-          id: PKCE_STATE_ECHO_FINDING_ID,
+          stem: PKCE_STATE_ECHO_FINDING_ID,
           title: 'Authorization endpoint did not echo state parameter correctly',
           severity: 'warn',
           passed: false,
@@ -308,7 +308,7 @@ function classifyAndEmit(
 
     // Off-host redirect (consent/login page).
     findings.push({
-      id: params.primaryFindingId,
+      stem: params.primaryFindingId,
       title: `PKCE enforcement could not be confirmed for ${params.primaryFindingTitleSubject}`,
       severity: 'warn',
       passed: false,
@@ -322,7 +322,7 @@ function classifyAndEmit(
 
   if (result.status === 200 || result.status === 401 || result.status === 403) {
     findings.push({
-      id: params.primaryFindingId,
+      stem: params.primaryFindingId,
       title: `PKCE enforcement could not be confirmed for ${params.primaryFindingTitleSubject}`,
       severity: 'warn',
       passed: false,
@@ -337,7 +337,7 @@ function classifyAndEmit(
   if (result.status === 400 || result.status === 422) {
     if (bodyMentionsPkce(result.body)) {
       findings.push({
-        id: params.primaryFindingId,
+        stem: params.primaryFindingId,
         title: `Authorization endpoint rejected ${params.primaryFindingTitleSubject} with HTTP ${result.status}`,
         severity: 'info',
         passed: true,
@@ -348,7 +348,7 @@ function classifyAndEmit(
       });
     } else {
       findings.push({
-        id: params.primaryFindingId,
+        stem: params.primaryFindingId,
         title: `Authorization endpoint returned HTTP ${result.status} for ${params.primaryFindingTitleSubject}`,
         severity: 'warn',
         passed: false,
@@ -362,7 +362,7 @@ function classifyAndEmit(
   }
 
   findings.push({
-    id: params.primaryFindingId,
+    stem: params.primaryFindingId,
     title: `Authorization endpoint returned unexpected response for ${params.primaryFindingTitleSubject}`,
     severity: 'warn',
     passed: false,

--- a/src/probes/prm.ts
+++ b/src/probes/prm.ts
@@ -4,18 +4,20 @@ import type { AuditContext, Evidence, Finding, NamedEvidence, ProbeResult } from
 export const PRM_PROBE_STEM = '02-prm';
 
 /**
- * Protected Resource Metadata, per RFC 9728 §3.
+ * Protected Resource Metadata, per RFC 9728 §2.
  *
- * Required: resource, authorization_servers.
- * Recommended: scopes_supported, bearer_methods_supported,
- * resource_documentation, resource_signing_alg_values_supported.
+ * Required: resource.
+ * Recommended: scopes_supported.
+ * Optional: authorization_servers, bearer_methods_supported,
+ * resource_documentation, resource_signing_alg_values_supported,
+ * jwks_uri, and others.
  *
- * Passthrough: RFC 9728 §3 permits extension fields; the schema
+ * Passthrough: RFC 9728 §2 permits additional parameters; the schema
  * must not reject unknown keys.
  */
 export const PrmSchema = z.object({
   resource: z.string().url(),
-  authorization_servers: z.array(z.string().url()).min(1),
+  authorization_servers: z.array(z.string().url()).min(1).optional(),
   scopes_supported: z.array(z.string()).optional(),
   bearer_methods_supported: z.array(z.string()).optional(),
   resource_documentation: z.string().url().optional(),
@@ -24,22 +26,23 @@ export const PrmSchema = z.object({
 
 export type Prm = z.infer<typeof PrmSchema>;
 
-const RECOMMENDED_FIELDS = [
-  'scopes_supported',
-  'bearer_methods_supported',
-  'resource_documentation',
-  'resource_signing_alg_values_supported'
-] as const;
+const RECOMMENDED_FIELDS = ['scopes_supported'] as const;
 
 /**
  * Probe 2: Protected Resource Metadata fetch and validation (RFC 9728).
  *
  * When probe 1 extracted `resource_metadata` from WWW-Authenticate, fetch
  * that URL directly. When that parameter is absent (see MCP 2025-11-25
- * §2.3.1 SHOULD), derive the well-known URL per RFC 9728 §3.1: try the
- * path-insertion form first, then the top-level form. Emit an info-finding
- * when fallback resolves the document, or an issue-finding when neither
- * derived form returns 2xx.
+ * §2.3.1 SHOULD), derive the well-known URL per RFC 9728 §3.1. §3.1
+ * selects the form by whether the resource identifier has a path or query
+ * component. With a path or query, the well-known suffix is inserted
+ * between the host and the path (any terminating slash after the host
+ * removed first); without one, the suffix sits at the top level. The
+ * probe queries the path-insertion form, the §3.1 location for a resource
+ * with a path, and only if that does not resolve additionally tries the
+ * top-level form to locate metadata published at the non-mandated
+ * location. Emits an info-finding when fallback resolves the document, or
+ * an issue-finding when neither derived form returns 2xx.
  */
 export async function prmProbe(ctx: AuditContext): Promise<ProbeResult> {
   const prmUrl = ctx.protectedResourceMetadataUrl;
@@ -53,9 +56,15 @@ export async function prmProbe(ctx: AuditContext): Promise<ProbeResult> {
 /**
  * RFC 9728 §3.1 fallback when WWW-Authenticate lacked resource_metadata.
  *
- * Probes path-insertion form first, top-level form second. When the target
- * has no path component both forms collapse to the same URL and only one
- * request is made.
+ * §3.1 selects the well-known URL form by whether the resource identifier
+ * has a path or query component. With a path or query, the suffix is
+ * inserted between host and the remaining path (any terminating slash
+ * after the host removed first); without one, the suffix sits at the top
+ * level. The probe queries the path-insertion form, the §3.1 location for
+ * a resource with a path, and only if that does not resolve additionally
+ * tries the top-level form to locate metadata published at the
+ * non-mandated location. When the target has no path component both forms
+ * collapse to the same URL and only one request is made.
  */
 async function runFallback(ctx: AuditContext): Promise<ProbeResult> {
   const { pathInsert, topLevel } = wellKnownUrls(ctx.target);
@@ -160,7 +169,7 @@ async function fetchAndValidate(
   const validation = validatePrmResponse(ctx, attempt);
 
   const finding: Finding = {
-    id: PRM_PROBE_STEM,
+    stem: PRM_PROBE_STEM,
     title: 'Protected Resource Metadata (RFC 9728)',
     severity: validation.passed ? 'info' : 'warn',
     passed: validation.passed,
@@ -195,7 +204,7 @@ function fallbackSuccess(
   const validation = validatePrmResponse(ctx, attempt);
 
   const validationFinding: Finding = {
-    id: PRM_PROBE_STEM,
+    stem: PRM_PROBE_STEM,
     title: 'Protected Resource Metadata (RFC 9728)',
     severity: validation.passed ? 'info' : 'warn',
     passed: validation.passed,
@@ -206,7 +215,7 @@ function fallbackSuccess(
   }
 
   const infoFinding: Finding = {
-    id: PRM_PROBE_STEM,
+    stem: PRM_PROBE_STEM,
     title: 'PRM discovery required well-known URL fallback',
     severity: 'info',
     passed: true,
@@ -260,7 +269,7 @@ function fallbackAllFailed(input: FallbackFailureInput): ProbeResult {
     : `WWW-Authenticate lacks resource_metadata parameter. Well-known URL path-insertion form (${input.pathInsertUrl}) returned ${input.pathInsertStatus}; top-level form (${input.topLevelUrl}) returned ${input.topLevelStatus}. A spec-compliant client cannot complete discovery.`;
 
   const finding: Finding = {
-    id: PRM_PROBE_STEM,
+    stem: PRM_PROBE_STEM,
     title: 'No RFC 9728 discovery path resolves',
     severity: 'issue',
     passed: false,
@@ -282,7 +291,7 @@ interface ValidationOutcome {
 }
 
 /**
- * Runs the existing zod schema + RFC 9728 §3 RECOMMENDED-field and §3.3
+ * Runs the existing zod schema + RFC 9728 §2 RECOMMENDED-field and §3.3
  * scope checks against a fetched PRM response. Behavior is unchanged from
  * the pre-fallback implementation; extracted so both the direct-URL and
  * fallback paths share the same validation.
@@ -312,14 +321,16 @@ function validatePrmResponse(ctx: AuditContext, attempt: FetchAttempt): Validati
   if (!parseResult.success) {
     for (const issue of parseResult.error.issues) {
       const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
-      observations.push(`PRM schema: ${path}: ${issue.message} (RFC 9728 §3)`);
+      observations.push(`PRM schema: ${path}: ${issue.message} (RFC 9728 §2)`);
     }
     return { passed, observations };
   }
 
   const prm = parseResult.data;
   observations.push(`resource: ${prm.resource}`);
-  observations.push(`authorization_servers: ${prm.authorization_servers.join(', ')}`);
+  if (prm.authorization_servers !== undefined) {
+    observations.push(`authorization_servers: ${prm.authorization_servers.join(', ')}`);
+  }
 
   const resourceUrl = safeUrl(prm.resource);
   const originMatch = resourceUrl !== null && resourceUrl.origin === ctx.target.origin;
@@ -334,15 +345,17 @@ function validatePrmResponse(ctx: AuditContext, attempt: FetchAttempt): Validati
 
   for (const field of RECOMMENDED_FIELDS) {
     if (prm[field] === undefined) {
-      observations.push(`RFC 9728 §3 recommends "${field}"; not present.`);
+      observations.push(`RFC 9728 §2 recommends "${field}"; not present.`);
     }
   }
 
   passed = originMatch && pathMatch;
   contextUpdates = {
-    protectedResourceMetadata: prm,
-    authorizationServers: prm.authorization_servers
+    protectedResourceMetadata: prm
   };
+  if (prm.authorization_servers !== undefined) {
+    contextUpdates.authorizationServers = prm.authorization_servers;
+  }
 
   return { passed, observations, contextUpdates };
 }

--- a/src/probes/token-hygiene.ts
+++ b/src/probes/token-hygiene.ts
@@ -33,21 +33,21 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
   const as = ctx.authorizationServerMetadata;
   if (!as) {
     findings.push({
-      id: TOKEN_HYGIENE_JWKS_URI_FINDING_ID,
+      stem: TOKEN_HYGIENE_JWKS_URI_FINDING_ID,
       title: JWKS_URI_TITLE_SKIPPED,
       severity: 'skipped',
       passed: false,
       observations: ['Skipped: probe 3 did not populate authorizationServerMetadata.']
     });
     findings.push({
-      id: TOKEN_HYGIENE_REVOCATION_FINDING_ID,
+      stem: TOKEN_HYGIENE_REVOCATION_FINDING_ID,
       title: REVOCATION_TITLE_SKIPPED,
       severity: 'skipped',
       passed: false,
       observations: ['Skipped: AS metadata not available.']
     });
     findings.push({
-      id: TOKEN_HYGIENE_INTROSPECTION_FINDING_ID,
+      stem: TOKEN_HYGIENE_INTROSPECTION_FINDING_ID,
       title: INTROSPECTION_TITLE_SKIPPED,
       severity: 'skipped',
       passed: false,
@@ -64,7 +64,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
     // --- B1: jwks_uri ---
     if (typeof jwksUri === 'string') {
       findings.push({
-        id: TOKEN_HYGIENE_JWKS_URI_FINDING_ID,
+        stem: TOKEN_HYGIENE_JWKS_URI_FINDING_ID,
         title: 'JWKS URI advertised',
         severity: 'info',
         passed: true,
@@ -75,7 +75,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
       });
     } else {
       findings.push({
-        id: TOKEN_HYGIENE_JWKS_URI_FINDING_ID,
+        stem: TOKEN_HYGIENE_JWKS_URI_FINDING_ID,
         title: 'JWKS URI not advertised',
         severity: 'info',
         passed: false,
@@ -89,7 +89,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
     // --- B2: revocation_endpoint ---
     if (typeof revocationEndpoint === 'string') {
       findings.push({
-        id: TOKEN_HYGIENE_REVOCATION_FINDING_ID,
+        stem: TOKEN_HYGIENE_REVOCATION_FINDING_ID,
         title: 'Revocation endpoint advertised (RFC 7009)',
         severity: 'info',
         passed: true,
@@ -100,7 +100,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
       });
     } else {
       findings.push({
-        id: TOKEN_HYGIENE_REVOCATION_FINDING_ID,
+        stem: TOKEN_HYGIENE_REVOCATION_FINDING_ID,
         title: 'Revocation endpoint not advertised (RFC 7009)',
         severity: 'warn',
         passed: false,
@@ -115,7 +115,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
     // --- B3: introspection_endpoint ---
     if (typeof introspectionEndpoint === 'string') {
       findings.push({
-        id: TOKEN_HYGIENE_INTROSPECTION_FINDING_ID,
+        stem: TOKEN_HYGIENE_INTROSPECTION_FINDING_ID,
         title: 'Introspection endpoint advertised (RFC 7662)',
         severity: 'info',
         passed: true,
@@ -126,7 +126,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
       });
     } else {
       findings.push({
-        id: TOKEN_HYGIENE_INTROSPECTION_FINDING_ID,
+        stem: TOKEN_HYGIENE_INTROSPECTION_FINDING_ID,
         title: 'Introspection endpoint not advertised (RFC 7662)',
         severity: 'info',
         passed: false,
@@ -142,7 +142,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
   const prm = ctx.protectedResourceMetadata;
   if (!prm) {
     findings.push({
-      id: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
+      stem: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
       title: BEARER_METHODS_TITLE_SKIPPED,
       severity: 'skipped',
       passed: false,
@@ -155,7 +155,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
 
     if (methods === undefined) {
       findings.push({
-        id: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
+        stem: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
         title: 'bearer_methods_supported not advertised',
         severity: 'info',
         passed: false,
@@ -172,7 +172,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
 
       if (hasQuery) {
         findings.push({
-          id: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
+          stem: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
           title: 'bearer_methods_supported includes query',
           severity: 'warn',
           passed: false,
@@ -184,7 +184,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
         });
       } else if (hasForm) {
         findings.push({
-          id: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
+          stem: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
           title: 'bearer_methods_supported includes form but not query',
           severity: 'info',
           passed: false,
@@ -195,7 +195,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
         });
       } else {
         findings.push({
-          id: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
+          stem: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
           title: 'bearer_methods_supported restricts to header only',
           severity: 'info',
           passed: true,
@@ -210,7 +210,7 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
 
   // --- Deferral finding (always emitted) ---
   findings.push({
-    id: TOKEN_HYGIENE_LIVE_TOKEN_DEFERRED_FINDING_ID,
+    stem: TOKEN_HYGIENE_LIVE_TOKEN_DEFERRED_FINDING_ID,
     title: 'Live-token hygiene tests deferred to future probe',
     severity: 'skipped',
     passed: false,

--- a/src/report.ts
+++ b/src/report.ts
@@ -45,7 +45,7 @@ function renderMarkdown({ target, findings, evidenceNames }: ReportInput): strin
   lines.push('');
 
   for (const finding of findings) {
-    lines.push(`### ${finding.id}: ${finding.title}`);
+    lines.push(`### ${finding.stem}: ${finding.title}`);
     lines.push('');
     lines.push(`**Result:** ${finding.passed ? 'passed' : finding.severity}`);
     lines.push('');

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface Evidence {
 export type Severity = 'info' | 'warn' | 'issue' | 'critical' | 'skipped';
 
 export interface Finding {
-  id: string;
+  stem: string;
   title: string;
   severity: Severity;
   passed: boolean;


### PR DESCRIPTION
## Summary

Source-verified citation corrections in probes 02 (PRM, RFC 9728) and 04 (DCR, RFC 7591 + OAuth 2.1), plus the queued field rename of `Finding.id` to `Finding.stem`.

## Probe 02 (`src/probes/prm.ts`)

Source basis: RFC 9728 §2 defines every PRM field and its requirement level. §3.1 defines the well-known URL by path-or-query presence on the resource identifier.

- `PrmSchema.authorization_servers` is now `.optional()`. Per RFC 9728 §2, only `resource` is REQUIRED. `scopes_supported` is RECOMMENDED. `authorization_servers`, `bearer_methods_supported`, `resource_documentation`, and `resource_signing_alg_values_supported` are all OPTIONAL.
- `RECOMMENDED_FIELDS` reduced to `['scopes_supported']`. Absence of the OPTIONAL fields is not a deviation.
- Schema-parse-failure observation and the recommended-absence observation cite RFC 9728 §2, not §3. All field definitions live in §2.
- The `PrmSchema` doc summary now lists Required, Recommended, and Optional accurately and notes the §2 passthrough permission for additional parameters.
- The `prmProbe` and `runFallback` doc comments reframe §3.1 as two cases by path-or-query presence, not as an ordered fallback. The probe still queries the path-insertion form first (the §3.1 location for a resource with a path) and only if that does not resolve additionally tries the top-level form to locate metadata published at the non-mandated location.
- `validatePrmResponse` emits the `authorization_servers:` observation and the `authorizationServers` context update only when the field is present. Pass criterion stays `originMatch && pathMatch`, independent of `authorization_servers` presence.
- The §3.1 trailing-slash citation in `wellKnownUrls` and the §3.3 origin/path-match citations are unchanged.

## Probe 04 (`src/probes/dcr.ts`)

Source basis: A non-loopback http redirect URI violates both RFC 7591 §5 ¶2 (three-class MUST) and OAuth 2.1 §1.5 (https for OAuth URLs, loopback excepted). The probe standardises on OAuth 2.1 §1.5 to match the published audits and disclosure correspondence. The rule is not confidential-client-specific.

- POST 2 fail branch: observation is now `POST returned 201; non-loopback HTTP redirect URIs must be rejected (OAuth 2.1 §1.5 MUST). The https requirement applies to all redirect-based clients; the client_secret_basic client here only isolates the scheme as the single variable.` Finding title changed to `DCR accepted non-loopback HTTP redirect URI`.
- POST 2 pass branch: citation changed from `RFC 7591 §5` to `OAuth 2.1 §1.5`. Title changed to `DCR rejected non-loopback HTTP redirect URI`.
- POST 3 host mismatch keeps the RFC 7591 §5 citation (verified correct) and softens `AS SHOULD reject this` to `AS SHOULD check this; §5 frames it as a host and scheme check that may lead to refusal, not a mandated rejection (RFC 7591 §5 SHOULD)`.
- 201-status observations: RFC 7591 §3.2 and §3.2.1 state the 201 declaratively and carry no explicit MUST keyword for the status code. `RFC 7591 §3.2.1 MUST requires HTTP 201` replaced with `RFC 7591 §3.2 specifies HTTP 201 for a successful registration`. The §3.2.1 client_id-in-body requirement keeps its own citation. The endpoint-TLS `RFC 7591 §3 MUST` citation is unchanged.
- Probe doc comment for concern (b): citation updated to `RFC 7591 §5 host-match SHOULD; OAuth 2.1 §1.5 https MUST`.

## Field rename

`Finding.id` renamed to `Finding.stem` across the type surface and every emitter and consumer:

- `src/types.ts`: interface field renamed.
- `src/probes/discovery.ts`, `src/probes/prm.ts`, `src/probes/as-metadata.ts`, `src/probes/dcr.ts`, `src/probes/pkce-enforcement.ts`, `src/probes/token-hygiene.ts`: all finding emitters set `stem:`.
- `src/audit.ts`: threw-finding constructor sets `stem:`.
- `src/report.ts`: heading renders `finding.stem`.

The JSON-RPC `id: 1` inside `MCP_INITIALIZE_BODY` in `discovery.ts` is unrelated to `Finding.id` and remains unchanged.

## Test plan

- [x] `pnpm typecheck` passes (strict + `noUncheckedIndexedAccess`).
- [ ] `pnpm lint`: no `lint` script defined in `package.json`.
- [ ] `pnpm test`: no `test` script defined in `package.json`. `CONTRIBUTING.md` mentions vitest, but no test directory, fixtures, or devDependency is present in the tree. A PRM-omits-`authorization_servers` test would land alongside the first test bring-up.
- [ ] Manual review of edited files against published RFC 9728, RFC 7591, and OAuth 2.1 text.

Do not merge. Issues #11, #22, #23 remain open; closures are founder actions.