### PR TITLE
probes: correct PRM discovery and bearer-method citations; fix form vs body

### DIFF
--- a/src/probes/as-metadata.ts
+++ b/src/probes/as-metadata.ts
@@ -309,7 +309,7 @@ function buildPkceMethodsFinding(metadataParsed: boolean, pkce: string[] | undef
       passed: false,
       observations: [
         'code_challenge_methods_supported not present in AS metadata.',
-        'RFC 8414 §2: if omitted, the authorization server does not support PKCE.'
+        'Absent code_challenge_methods_supported is treated as no PKCE support (OAuth 2.1 §4.1.1; MCP 2025-11-25 requires clients to refuse to proceed when it is absent).'
       ],
       evidence: [AS_METADATA_PROBE_STEM]
     };

--- a/src/probes/discovery.ts
+++ b/src/probes/discovery.ts
@@ -219,7 +219,8 @@ export interface WwwAuthChallenge {
 }
 
 /**
- * Parse a single Bearer WWW-Authenticate challenge per RFC 7235 §2.1.
+ * Parse a single Bearer WWW-Authenticate challenge per RFC 9110 §11.1
+ * (Challenge and Response; RFC 7235 was obsoleted by RFC 9110).
  *
  * Handles token and quoted-string param values, quoted-pair escaping,
  * and optional whitespace around "=" and ",". Multi-challenge responses

--- a/src/probes/prm.ts
+++ b/src/probes/prm.ts
@@ -32,8 +32,10 @@ const RECOMMENDED_FIELDS = ['scopes_supported'] as const;
  * Probe 2: Protected Resource Metadata fetch and validation (RFC 9728).
  *
  * When probe 1 extracted `resource_metadata` from WWW-Authenticate, fetch
- * that URL directly. When that parameter is absent (see MCP 2025-11-25
- * §2.3.1 SHOULD), derive the well-known URL per RFC 9728 §3.1. §3.1
+ * that URL directly. When that parameter is absent, the server relies on
+ * the well-known URI discovery mechanism (MCP 2025-11-25, Protected
+ * Resource Metadata Discovery Requirements); derive the well-known URL
+ * per RFC 9728 §3.1. §3.1
  * selects the form by whether the resource identifier has a path or query
  * component. With a path or query, the well-known suffix is inserted
  * between the host and the path (any terminating slash after the host
@@ -220,7 +222,7 @@ function fallbackSuccess(
     severity: 'info',
     passed: true,
     observations: [
-      `WWW-Authenticate did not include resource_metadata parameter. PRM resolved at ${url}. MCP spec 2025-11-25 §2.3.1 recommends (SHOULD) that servers include resource_metadata on 401/403 responses.`
+      `WWW-Authenticate did not include resource_metadata; the PRM resolved at ${url} via the well-known URI. MCP 2025-11-25 (Protected Resource Metadata Discovery Requirements) lets a server satisfy discovery with either the resource_metadata parameter in the WWW-Authenticate header on a 401 (RFC 9728 §5.1) or the well-known URI. This server used the well-known URI, so discovery succeeds; advertising resource_metadata in the challenge would save clients the fallback request.`
     ]
   };
 

--- a/src/probes/token-hygiene.ts
+++ b/src/probes/token-hygiene.ts
@@ -10,7 +10,7 @@ export const TOKEN_HYGIENE_LIVE_TOKEN_DEFERRED_FINDING_ID = '06-token-hygiene-li
 const JWKS_URI_TITLE_SKIPPED = 'JWKS URI advertisement (RFC 8414 §2)';
 const REVOCATION_TITLE_SKIPPED = 'Revocation endpoint advertisement (RFC 7009)';
 const INTROSPECTION_TITLE_SKIPPED = 'Introspection endpoint advertisement (RFC 7662)';
-const BEARER_METHODS_TITLE_SKIPPED = 'Bearer methods advertisement (RFC 6750 §2.3)';
+const BEARER_METHODS_TITLE_SKIPPED = 'Bearer methods advertisement (RFC 9728 §2)';
 
 /**
  * Probe 6: token-hygiene metadata signals.
@@ -161,14 +161,14 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
         passed: false,
         observations: [
           'bearer_methods_supported absent from PRM.',
-          'RFC 6750 default allows all three bearer methods (header, query, form).',
+          'The three RFC 6750 bearer methods are header (§2.1), body (§2.2), and query (§2.3); with bearer_methods_supported absent (RFC 9728 §2), none is explicitly excluded.',
           'No explicit restriction; URL-borne token risk cannot be ruled out from metadata alone.'
         ]
       });
     } else {
       const joined = methods.join(', ');
       const hasQuery = methods.includes('query');
-      const hasForm = methods.includes('form');
+      const hasBody = methods.includes('body');
 
       if (hasQuery) {
         findings.push({
@@ -182,15 +182,15 @@ export async function tokenHygieneProbe(ctx: AuditContext): Promise<ProbeResult>
             'RFC 6750 §5.3 advises against URL query string bearer tokens.'
           ]
         });
-      } else if (hasForm) {
+      } else if (hasBody) {
         findings.push({
           stem: TOKEN_HYGIENE_BEARER_METHODS_FINDING_ID,
-          title: 'bearer_methods_supported includes form but not query',
+          title: 'bearer_methods_supported includes body but not query',
           severity: 'info',
           passed: false,
           observations: [
             `bearer_methods_supported: [${joined}]`,
-            'form method accepted. Lower risk than query; not logged in access logs by default.'
+            'body method accepted. Lower risk than query; not logged in access logs by default.'
           ]
         });
       } else {


### PR DESCRIPTION
## Summary

Five citation fixes and one logic bug across four probe files. Each item below names the changed site and the source basis.

### prm.ts: MCP discovery citation (two sites)

The `fallbackSuccess` observation and the `prmProbe` JSDoc both cited MCP 2025-11-25 "§2.3.1" with a SHOULD framing. The 2025-11-25 authorization spec uses titled (not numbered) sections, so §2.3.1 does not exist. Under the section titled "Protected Resource Metadata Discovery Requirements" a server MUST implement one of two mechanisms:

- `resource_metadata` parameter in the WWW-Authenticate header on a 401 (RFC 9728 §5.1), or
- the well-known URI (RFC 9728 §3.1).

A server serving the well-known URI is compliant. The observation now says exactly that: discovery succeeded via the well-known URI, and advertising `resource_metadata` in the challenge would save clients the fallback request. The doc comment is reworded to drop the §2.3.1 SHOULD framing.

### token-hygiene.ts: BEARER_METHODS_TITLE_SKIPPED citation

The constant was titled "Bearer methods advertisement (RFC 6750 §2.3)". The field `bearer_methods_supported` is defined in RFC 9728 §2. RFC 6750 §2.3 is the URI-query bearer method only. Retitled to "Bearer methods advertisement (RFC 9728 §2)".

### token-hygiene.ts: B4 bearer-method value bug ("form" was never a valid value)

RFC 9728 §2 defines `bearer_methods_supported` values as "header", "body", and "query", mapping to RFC 6750 §2.1, §2.2, §2.3. "form" is not a defined value, so the second-branch check was unreachable for spec-compliant servers and would mislabel a "body" advertisement.

- Rename local `hasForm` to `hasBody`; initializer switched from `methods.includes('form')` to `methods.includes('body')`.
- Branch condition `else if (hasForm)` to `else if (hasBody)`.
- Finding title "bearer_methods_supported includes form but not query" to "bearer_methods_supported includes body but not query".
- Observation "form method accepted..." to "body method accepted...".
- Absent-field observation replaced: now lists the three RFC 6750 methods with section numbers (header §2.1, body §2.2, query §2.3) and cites RFC 9728 §2 for the field. The previous text named the nonexistent "form" value.

The query-method branch is unchanged; its RFC 6750 §5.3 citation is correct.

### as-metadata.ts: PKCE absent-branch observation

The text said "RFC 8414 §2: if omitted, the authorization server does not support PKCE." RFC 8414 §2 defines the field but does not state the absence semantic. The "absent equals no PKCE" interpretation is from OAuth 2.1 §4.1.1, and MCP 2025-11-25 requires clients to refuse to proceed when the field is absent. Citation corrected accordingly.

### discovery.ts: parseWwwAuthenticate doc comment

The doc cited "RFC 7235 §2.1". RFC 7235 has been obsoleted by RFC 9110; the Challenge and Response text now lives at RFC 9110 §11.1. Updated to "RFC 9110 §11.1 (Challenge and Response; RFC 7235 was obsoleted by RFC 9110)".

## Test plan

- [x] `pnpm typecheck` clean (the `hasForm` to `hasBody` rename touches a local variable used in two sites; both updated).
- [ ] No lint or test scripts exist in this repo to run.
- [ ] Reviewer to confirm RFC and MCP citations against the published source documents.