### PR TITLE
fix(probes): parse unquoted resource_metadata URLs in WWW-Authenticate

### DIFF
--- a/src/probes/discovery.ts
+++ b/src/probes/discovery.ts
@@ -272,7 +272,14 @@ function consumeParam(input: string): { key: string; value: string; rest: string
     value = v;
     r = r.slice(i);
   } else {
-    const tokenMatch = /^[A-Za-z0-9!#$%&'*+.^_`|~\/\-=]+/.exec(r);
+    // RFC 9110 §5.6.2 token grammar excludes ":" "/" "?" "=" (delimiters), so an
+    // unquoted URL is non-conformant: RFC 9728 §5.1 resource_metadata URLs are
+    // meant to be sent as a quoted-string. Some servers emit the URL unquoted,
+    // so this branch leniently accepts URL-structural delimiters to capture the
+    // whole value. "/" and "=" were already accepted; ":" and "?" are added so
+    // "https://host/path?x=y" no longer truncates at the scheme colon to "https".
+    // Do not narrow this back to strict tchar.
+    const tokenMatch = /^[A-Za-z0-9!#$%&'*+.^_`|~:?\/\-=]+/.exec(r);
     if (!tokenMatch) return null;
     value = tokenMatch[0];
     r = r.slice(tokenMatch[0].length);

--- a/src/probes/prm.ts
+++ b/src/probes/prm.ts
@@ -49,6 +49,22 @@ const RECOMMENDED_FIELDS = ['scopes_supported'] as const;
 export async function prmProbe(ctx: AuditContext): Promise<ProbeResult> {
   const prmUrl = ctx.protectedResourceMetadataUrl;
   if (prmUrl) {
+    // A malformed advertised value (e.g. a non-absolute URL) must not crash the
+    // audit: fetch() throws synchronously on an unparseable URL and nothing here
+    // catches it. Record a finding and fall back to well-known discovery instead.
+    if (safeUrl(prmUrl) === null) {
+      const fallback = await runFallback(ctx);
+      const malformed: Finding = {
+        stem: PRM_PROBE_STEM,
+        title: 'WWW-Authenticate resource_metadata is not an absolute URL (RFC 9728 §5.1)',
+        severity: 'warn',
+        passed: false,
+        observations: [
+          `WWW-Authenticate advertised resource_metadata="${prmUrl}", which does not parse as an absolute URL and cannot be dereferenced (RFC 9728 §5.1). Fell back to well-known discovery.`
+        ]
+      };
+      return { ...fallback, findings: [malformed, ...fallback.findings] };
+    }
     return fetchAndValidate(ctx, prmUrl, PRM_PROBE_STEM);
   }
 


### PR DESCRIPTION
The probe-01 WWW-Authenticate parser truncated an unquoted resource_metadata URL at the scheme colon. RFC 9110 §5.6.2 token grammar excludes ":" "/" "?" "=", so an unquoted URL is non-conformant and RFC 9728 §5.1 resource_metadata URLs are meant to be sent as a quoted-string. The token branch already accepted "/" and "=" leniently but omitted ":", so "resource_metadata=https://host/..." parsed to "https" and propagated to probe-02.

discovery.ts: add ":" and "?" to the unquoted-value character class so a full URL is captured.

prm.ts: guard prmProbe against a non-absolute advertised value. fetch() throws synchronously on an unparseable URL with no catch on that path, so a malformed resource_metadata value crashed the whole audit. The guard records a warn finding and falls back to well-known discovery (RFC 9728 §3.1) instead.

Verification: pnpm typecheck clean; parser returns the full URL for an unquoted resource_metadata value. No test runner is wired in this repo.
