### PR TITLE
docs(security): use founder@korrel.dev as the SECURITY.md disclosure address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,7 +77,7 @@ filing was in error, are tracked in
 
 ## How to disclose
 
-Email `security@korrel.dev` with:
+Email `founder@korrel.dev` with:
 
 - The category from the list above.
 - The probe (1-6 per `METHODOLOGY.md`) and the source file path
@@ -132,7 +132,7 @@ covers the audit content and evidence files.
 - Issues in the [Model Context Protocol](https://github.com/modelcontextprotocol)
   specification. Disclose to the spec maintainers.
 - Issues in [korrel.dev](https://korrel.dev) (the company website)
-  or the Korrel managed cloud. Email `security@korrel.dev` with
+  or the Korrel managed cloud. Email `founder@korrel.dev` with
   the product name in the subject line.
 
 ## Hall of fame


### PR DESCRIPTION
SECURITY.md published security@korrel.dev as the disclosure address, but that inbox is not provisioned, so disclosure email to it bounces. Point the disclosure address at founder@korrel.dev, the live inbox that has handled every disclosure to date. Address-only change; no other content modified.